### PR TITLE
【最新版】Sinatraアプリでのデータ保存先をDBに変える

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,8 @@ bundle install
 - ターミナルで
 
 ```
-bundle exec ruby main.rb
+ruby main.rb
 ```
 を実行します。
 
 - ブラウザを開いて、`localhost:4567/memos`にアクセスできればメモアプリが使用できます。
-
-## 投稿したメモの保存先
-  新規投稿したメモは、`memos`ディレクトリに自動的にjsonファイルとして保存されます。

--- a/main.rb
+++ b/main.rb
@@ -1,28 +1,32 @@
 # frozen_string_literal: true
 
+# !/usr/bin/env ruby
+
 require 'sinatra'
 require 'sinatra/reloader'
 require 'securerandom'
-require 'json'
+require 'pg'
 
 # About memo app class
 class Memo
+  @connection = PG.connect(dbname: 'database-memo')
+
   def self.create(title:, content:)
-    memo_contents = { id: SecureRandom.uuid, title: title, content: content }
-    File.open("./memos/#{memo_contents[:id]}.json", 'w') { |file| file.puts JSON.pretty_generate(memo_contents) }
+    @connection.exec("INSERT INTO memotable(id, title, content)
+    VALUES ($1, $2, $3)", [SecureRandom.uuid, title, content])
   end
 
   def self.find(id:)
-    JSON.parse(File.open("./memos/#{id}.json").read, symbolize_names: true)
+    @connection.exec('SELECT * FROM memotable WHERE id = $1', [id]).to_a.first
   end
 
   def self.update(id:, title:, content:)
-    new_contents = { id: id, title: title, content: content }
-    File.open("./memos/#{new_contents[:id]}.json", 'w') { |file| file.puts JSON.pretty_generate(new_contents) }
+    @connection.exec('UPDATE memotable SET title = $1, content = $2 WHERE id = $3',
+                     [title, content, id]).to_a.first
   end
 
   def self.destroy(id:)
-    File.delete("./memos/#{id}.json")
+    @connection.exec('DELETE FROM memotable WHERE id = $1', [id]).to_a.first
   end
 end
 
@@ -33,8 +37,14 @@ helpers do
 end
 
 get '/memos' do
-  memo_list = Dir.glob('./memos/*.json')
-  @memos = memo_list.map { |memo| JSON.parse(File.read(memo), symbolize_names: true) }
+  memo_contents = {}
+  @memos = []
+  connection = PG.connect(dbname: 'database-memo')
+  connection.exec('SELECT * FROM memotable') do |result|
+    result.each do |row|
+      @memos << memo_contents = { id: row['id'], title: row['title'], content: row['content'] }
+    end
+  end
   erb :index
 end
 
@@ -59,7 +69,7 @@ get '/memos/:id/edit' do
 end
 
 patch '/memos/:id' do
-  @memo = Memo.update(id: params[:id], title: h(params[:title]), content: h(params[:content]))
+  @memo = Memo.update(id: params[:id], title: params[:title], content: params[:content])
   redirect '/memos'
   erb :edit
 end

--- a/main.rb
+++ b/main.rb
@@ -22,11 +22,11 @@ class Memo
 
   def self.update(id:, title:, content:)
     @connection.exec('UPDATE memotable SET title = $1, content = $2 WHERE id = $3',
-                     [title, content, id]).to_a.first
+                     [title, content, id])
   end
 
   def self.destroy(id:)
-    @connection.exec('DELETE FROM memotable WHERE id = $1', [id]).to_a.first
+    @connection.exec('DELETE FROM memotable WHERE id = $1', [id])
   end
 end
 
@@ -39,7 +39,7 @@ end
 get '/memos' do
   @memos = []
   connection = PG.connect(dbname: 'database-memo')
-  connection.exec('SELECT * FROM memotable') do |result|
+  connection.exec('SELECT * FROM memotable ORDER BY title ASC') do |result|
     result.each do |row|
       @memos << { id: row['id'], title: row['title'], content: row['content'] }
     end

--- a/main.rb
+++ b/main.rb
@@ -18,7 +18,6 @@ class Memo
 
   def self.find(id:)
     @connection.exec('SELECT * FROM memotable WHERE id = $1', [id])[0]
-    binding.irb
   end
 
   def self.update(id:, title:, content:)
@@ -38,12 +37,11 @@ helpers do
 end
 
 get '/memos' do
-  memo_contents = {}
   @memos = []
   connection = PG.connect(dbname: 'database-memo')
   connection.exec('SELECT * FROM memotable') do |result|
     result.each do |row|
-      @memos << memo_contents = { id: row['id'], title: row['title'], content: row['content'] }
+      @memos << { id: row['id'], title: row['title'], content: row['content'] }
     end
   end
   erb :index

--- a/main.rb
+++ b/main.rb
@@ -22,11 +22,11 @@ class Memo
 
   def self.update(id:, title:, content:)
     @connection.exec('UPDATE memotable SET title = $1, content = $2 WHERE id = $3',
-                     [title, content, id])[0]
+                     [title, content, id]).to_a.first
   end
 
   def self.destroy(id:)
-    @connection.exec('DELETE FROM memotable WHERE id = $1', [id])[0]
+    @connection.exec('DELETE FROM memotable WHERE id = $1', [id]).to_a.first
   end
 end
 

--- a/main.rb
+++ b/main.rb
@@ -17,16 +17,17 @@ class Memo
   end
 
   def self.find(id:)
-    @connection.exec('SELECT * FROM memotable WHERE id = $1', [id]).to_a.first
+    @connection.exec('SELECT * FROM memotable WHERE id = $1', [id])[0]
+    binding.irb
   end
 
   def self.update(id:, title:, content:)
     @connection.exec('UPDATE memotable SET title = $1, content = $2 WHERE id = $3',
-                     [title, content, id]).to_a.first
+                     [title, content, id])[0]
   end
 
   def self.destroy(id:)
-    @connection.exec('DELETE FROM memotable WHERE id = $1', [id]).to_a.first
+    @connection.exec('DELETE FROM memotable WHERE id = $1', [id])[0]
   end
 end
 

--- a/views/edit.erb
+++ b/views/edit.erb
@@ -1,11 +1,11 @@
 <%# メモの編集ページ %>
-<form action="/memos/<%= @memo[:id] %>" method="post">
+<form action="/memos/<%= @memo["id"] %>" method="post">
   <div class="title">
-    タイトル<input class="title_form" type="text" name="title" value="<%= h(@memo[:title]) %>">
+    タイトル<input class="title_form" type="text" name="title" value="<%= h(@memo["title"]) %>">
   </div>
   <div class="content">
     <label>内容</label>
-      <textarea class="content_form" name="content"><%= h(@memo[:content]) %></textarea>
+      <textarea class="content_form" name="content"><%= h(@memo["content"]) %></textarea>
   </div>
   <button class="button" name="_method" value="PATCH">変更する</button>
 </form>

--- a/views/show.erb
+++ b/views/show.erb
@@ -1,9 +1,9 @@
 <%# メモの詳細ページ %>
-<div class="title">タイトル：<%= h(@memo[:title]) %></div>
-<div class="content">メモの内容：<%= h(@memo[:content]) %></div>
+<div class="title">タイトル：<%= h(@memo["title"]) %></div>
+<div class="content">メモの内容：<%= h(@memo["content"]) %></div>
 <div class="showpage_button">
-  <button class="button" onclick="location.href='/memos/<%= @memo[:id] %>/edit'" >変更する</button>
-  <form action="/memos/<%= @memo[:id] %>" method="post">
+  <button class="button" onclick="location.href='/memos/<%= @memo['id'] %>/edit'" >変更する</button>
+  <form action="/memos/<%= @memo["id"] %>" method="post">
     <button class="button" name="_method" value="DELETE">削除する</button>
   </form>
   <button class="button" onclick="location.href='/memos'" >メモ一覧へ</button>


### PR DESCRIPTION
## 実装内容

以前に制作したSinatraのメモアプリのDB保存版です。

- DBはPostgreSQLを使いました
- DBアクセスのライブラリにはActiveRecordは使わず、pgを使いました
- SQLインジェクションの対策済み（エスケープ処理、バインド機構）

ご確認よろしくお願いします。